### PR TITLE
Removing unnecessary square root.

### DIFF
--- a/test_wct.lua
+++ b/test_wct.lua
@@ -212,8 +212,8 @@ function feature_wct(contentFeature, styleFeature)
        end
     end
 
-    local c_d = c_e[{{1,k_c}}]:sqrt():pow(-1)
-    local s_d1 = s_e[{{1,k_s}}]:sqrt()
+    local c_d = c_e[{{1,k_c}}]:pow(-1)
+    local s_d1 = s_e[{{1,k_s}}]
 
     local whiten_contentFeature = nil
     local targetFeature = nil


### PR DESCRIPTION
From my understanding the SVD sigma matrix contains the square root of the eigenvalues of the right and left singular vectors thus performing another square root is not required. I may however be incorrect.